### PR TITLE
use shell=True for subprocess commands. 

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ Config = namedtuple(
 
 def get_head_commit():
     process = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
+        "git rev-parse HEAD",
         stdout=subprocess.PIPE,
         stderr=sys.stderr.buffer,
         universal_newlines=True,
@@ -33,7 +33,7 @@ def get_head_commit():
 
 def get_merge_base(main_branch, head_commit):
     process = subprocess.run(
-        ["git", "merge-base", f"origin/{main_branch}", head_commit],
+        f"git merge-base origin/{main_branch} {head_commit}",
         stdout=subprocess.PIPE,
         stderr=sys.stderr.buffer,
         universal_newlines=True,
@@ -46,13 +46,7 @@ def get_changed_files(main_branch):
     head_commit = get_head_commit()
     merge_base = get_merge_base(main_branch, head_commit)
     process = subprocess.run(
-        [
-            "git",
-            "diff",
-            "--diff-filter=d",
-            "--name-only",
-            f"{merge_base}..{head_commit}",
-        ],
+        f"git diff --diff-filter=d --name-only {merge_base}..{head_commit}",
         stdout=subprocess.PIPE,
         stderr=sys.stderr.buffer,
         universal_newlines=True,
@@ -72,6 +66,7 @@ def invoke_black_on_changed_files(args, changed_python_files):
         f.writelines(changed_python_files)
 
     cmd = ["cat", "/tmp/changed_python_files.txt", "|", "xargs", "black"] + args
+    cmd = " ".join(cmd)
     process = subprocess.run(
         cmd,
         stdout=subprocess.PIPE,
@@ -84,8 +79,10 @@ def invoke_black_on_changed_files(args, changed_python_files):
 
 
 def invoke_black_on_all_files(args):
+    cmd = ["black"] + args + ["."]
+    cmd = " ".join(cmd)
     process = subprocess.run(
-        ["black"] + args + ["."],
+        cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ def get_head_commit():
         stdout=subprocess.PIPE,
         stderr=sys.stderr.buffer,
         universal_newlines=True,
+        shell=True,
     )
     if process.returncode != 0:
         raise Exception(f"unexpected non-zero return code from git: {repr(process)}")
@@ -36,6 +37,7 @@ def get_merge_base(main_branch, head_commit):
         stdout=subprocess.PIPE,
         stderr=sys.stderr.buffer,
         universal_newlines=True,
+        shell=True,
     )
     return process.stdout
 
@@ -54,6 +56,7 @@ def get_changed_files(main_branch):
         stdout=subprocess.PIPE,
         stderr=sys.stderr.buffer,
         universal_newlines=True,
+        shell=True,
     )
     changed_python_files = []
     for f in process.stdout.splitlines():
@@ -74,6 +77,7 @@ def invoke_black_on_changed_files(args, changed_python_files):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,
+        shell=True,
     )
     all_output = str(process.stdout or "") + str(process.stderr or "")
     return process.returncode, all_output
@@ -85,6 +89,7 @@ def invoke_black_on_all_files(args):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,
+        shell=True,
     )
     all_output = str(process.stdout or "") + str(process.stderr or "")
     return process.returncode, all_output


### PR DESCRIPTION
Something caused this to start failing unexpectedly. It's possible GH runners changed some underlying behavior that is unknown?