### PR TITLE
Fix dubious ownership git error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,6 @@
 set -e # Increase bash strictness
 set -o pipefail
 
+git config --global --add safe.directory /github/workspace
+
 python /main.py


### PR DESCRIPTION
This should resolve the dubious ownership error we're seeing from git:
```
fatal: detected dubious ownership in repository at '/github/workspace'
```
