### PR TITLE
Fix "Invalid value for SRC ..." error

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ def invoke_black_on_changed_files(args, changed_python_files):
     if not changed_python_files:
         return 0, ""
     with open("/tmp/changed_python_files.txt", "w") as f:
-        f.writelines(changed_python_files)
+        f.writelines([file_path + "\n" for file_path in changed_python_files])
 
     cmd = ["cat", "/tmp/changed_python_files.txt", "|", "xargs", "black"] + args
     cmd = " ".join(cmd)


### PR DESCRIPTION
This should fix the following error:
```
[action-black][process:black] Usage: black [OPTIONS] SRC ...
[action-black][process:black] Try 'black -h' for help.
[action-black][process:black]
[action-black][process:black] Error: Invalid value for 'SRC ...': Path 'redacted/path/to/some/file.pyanother/redacted/path/to/some/file.py' does not exist.
[action-black][process:black]
[action-black] INFO: no formatted changes found.
```
The issue is due to the lack of a space character between the two paths. This is happening because we're feeding `xargs` an invalid file (no newline character between the file paths)