### PR TITLE
Error code 0 should not be treated as an error condition

### DIFF
--- a/main.py
+++ b/main.py
@@ -143,7 +143,7 @@ def main(config):
             print(
                 f"[action-black] ERROR: (non-formatting) Black found a syntax error when checking the files (error code: {retcode})."
             )
-        else:
+        elif retcode != 0:
             print(
                 f"[action-black] ERROR: (non-formatting) Something went wrong while trying to run the black formatter (error code: {retcode})."
             )


### PR DESCRIPTION
When there's no formatting issues reported by black, the GitHub action ends with a non zero error code and the following message:

  ERROR: (non-formatting) Something went wrong while trying to run the black formatter (error code: 0).